### PR TITLE
gradle에 protoc 코드 생성위치 변경/자동생성 source 폴더 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 build/
 out/
 
+.settings/
+bin/
+gen-src/
+.classpath
+.project

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ buildscript {
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:3.6.1"
+	// Set the location of generated source code by protoc compiler
+	generatedFilesBaseDir = "$projectDir/gen-src"
     }
     plugins {
         grpc {
@@ -38,13 +40,22 @@ protobuf {
     }
 }
 
+// Add source dir for generated source code of gRPC
+sourceSets {
+    main {
+        java {
+            srcDirs 'gen-src/main/java'
+            srcDirs 'gen-src/main/grpc'
+        }
+    }
+ }
+
 dependencies {
     compile 'io.grpc:grpc-core:1.16.1'
     compile 'io.grpc:grpc-netty:1.16.1'
     compile 'io.grpc:grpc-protobuf:1.16.1'
     compile 'io.grpc:grpc-stub:1.16.1'
     compile 'com.google.protobuf:protobuf-java:3.6.1'
-
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
코드 Clone 후 build시 IDE에서 발생하는 컴파일 오류 제거.

- gradle protoc 설정에 코드 생성위치 지정
- protoc에서 생성한 코드를 source folder로 지정
- etc. gitignore 추가.